### PR TITLE
API 호출 함수를 페이지 요소로부터 분리 #15

### DIFF
--- a/src/apis/AbstractApi.ts
+++ b/src/apis/AbstractApi.ts
@@ -1,0 +1,63 @@
+import { BackendErrorResponse } from "../server";
+
+export class AbstractApi {
+  private readonly accessToken: string;
+  private readonly baseUrl: string;
+
+  constructor(baseUrl: string, accessToken?: string) {
+    this.baseUrl = baseUrl;
+    this.accessToken = accessToken || "";
+  }
+
+  /**
+   * 자식 클래스에서 재사용할 request 메소드
+   */
+  protected async request<T>(
+    method: string,
+    endpointUrl: string,
+    inputBody: object | null
+  ): Promise<T> {
+    const url = `${this.baseUrl}${endpointUrl}`;
+    const requestConfig = this.createFetchConfig(method, inputBody);
+    const response = await fetch(url, requestConfig);
+
+    await this.assertResponseIsOk(response);
+    return response.json() as T;
+  }
+
+  private createFetchConfig(requestMethod: string, inputData: object | null) {
+    const config = {
+      method: requestMethod,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    };
+
+    if (inputData) {
+      Object.defineProperty(config, "body", JSON.stringify(inputData));
+    }
+
+    if (this.accessToken) {
+      Object.defineProperty(
+        config.headers,
+        "Authorization",
+        `Bearer ${this.accessToken}`
+      );
+    }
+
+    return config;
+  }
+
+  private async assertResponseIsOk(response: Response) {
+    if (!response.ok) {
+      const errorMessage = await this.extractBackendErrorMessage(response);
+      console.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+  }
+
+  private async extractBackendErrorMessage(response: Response) {
+    const responseBody = await response.json();
+    return (responseBody as BackendErrorResponse).message;
+  }
+}

--- a/src/apis/AuthApi.ts
+++ b/src/apis/AuthApi.ts
@@ -15,18 +15,14 @@ interface SignInApiResponse {
 }
 
 export class AuthApi extends AbstractApi {
-  async signInApi(signInFormData: SigninFormData) {
+  async signInApi(form: SigninFormData) {
     const url = "/auth/signin";
-    const response = await this.request<SignInApiResponse>(
-      "post",
-      url,
-      signInFormData
-    );
+    const response = await this.request<SignInApiResponse>("post", url, form);
     return response.acess_token;
   }
 
-  async signUpApi(signupFormData: SignupFormData) {
+  async signUpApi(form: SignupFormData) {
     const url = "/auth/signup";
-    await this.request("post", url, signupFormData);
+    await this.request("post", url, form);
   }
 }

--- a/src/apis/AuthApi.ts
+++ b/src/apis/AuthApi.ts
@@ -1,0 +1,61 @@
+import { BackendErrorResponse } from "../server";
+
+export interface SignupFormData {
+  email: string;
+  password: string;
+}
+
+export interface SigninFormData {
+  email: string;
+  password: string;
+}
+
+export interface SignInApiResponse {
+  acess_token: string;
+}
+
+export class AuthApi {
+  private readonly baseUrl: string;
+
+  constructor(baseUrl: string) {
+    this.baseUrl = baseUrl;
+  }
+
+  // TODO: 반환된 accessToken을 저장, 중복된 코드 컴포넌트화
+  async signInApi(signInFormData: SigninFormData): Promise<string> {
+    const response = await this.postWithBody<SignInApiResponse>(
+      "/auth/signin",
+      signInFormData
+    );
+    return response.acess_token;
+  }
+
+  async signUpApi(signupFormData: SignupFormData): Promise<void> {
+    await this.postWithBody("/auth/signup", signupFormData);
+  }
+
+  private async postWithBody<T>(
+    endpointUrl: string,
+    inputData: object
+  ): Promise<T> {
+    const response = await fetch(`${this.baseUrl}${endpointUrl}`, {
+      body: JSON.stringify(inputData),
+      method: "post",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      const errorMessage = await this.extractBackendErrorMessage(response);
+      console.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+    return response.json() as T;
+  }
+
+  private async extractBackendErrorMessage(response: Response) {
+    const responseBody = await response.json();
+    return (responseBody as BackendErrorResponse).message;
+  }
+}

--- a/src/apis/AuthApi.ts
+++ b/src/apis/AuthApi.ts
@@ -1,4 +1,4 @@
-import { BackendErrorResponse } from "../server";
+import { AbstractApi } from "./AbstractApi";
 
 export interface SignupFormData {
   email: string;
@@ -10,52 +10,23 @@ export interface SigninFormData {
   password: string;
 }
 
-export interface SignInApiResponse {
+interface SignInApiResponse {
   acess_token: string;
 }
 
-export class AuthApi {
-  private readonly baseUrl: string;
-
-  constructor(baseUrl: string) {
-    this.baseUrl = baseUrl;
-  }
-
-  // TODO: 반환된 accessToken을 저장, 중복된 코드 컴포넌트화
-  async signInApi(signInFormData: SigninFormData): Promise<string> {
-    const response = await this.postWithBody<SignInApiResponse>(
-      "/auth/signin",
+export class AuthApi extends AbstractApi {
+  async signInApi(signInFormData: SigninFormData) {
+    const url = "/auth/signin";
+    const response = await this.request<SignInApiResponse>(
+      "post",
+      url,
       signInFormData
     );
     return response.acess_token;
   }
 
-  async signUpApi(signupFormData: SignupFormData): Promise<void> {
-    await this.postWithBody("/auth/signup", signupFormData);
-  }
-
-  private async postWithBody<T>(
-    endpointUrl: string,
-    inputData: object
-  ): Promise<T> {
-    const response = await fetch(`${this.baseUrl}${endpointUrl}`, {
-      body: JSON.stringify(inputData),
-      method: "post",
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
-
-    if (!response.ok) {
-      const errorMessage = await this.extractBackendErrorMessage(response);
-      console.error(errorMessage);
-      throw new Error(errorMessage);
-    }
-    return response.json() as T;
-  }
-
-  private async extractBackendErrorMessage(response: Response) {
-    const responseBody = await response.json();
-    return (responseBody as BackendErrorResponse).message;
+  async signUpApi(signupFormData: SignupFormData) {
+    const url = "/auth/signup";
+    await this.request("post", url, signupFormData);
   }
 }

--- a/src/apis/TodoApis.ts
+++ b/src/apis/TodoApis.ts
@@ -1,0 +1,37 @@
+import { AbstractApi } from "./AbstractApi";
+
+export interface TodoListItemData {
+  id: number;
+  todo: string;
+  isCompleted: boolean;
+  userId: number;
+}
+
+export class TodoApi extends AbstractApi {
+  async fetchTodos() {
+    const url = "/todos";
+    return this.request<TodoListItemData[]>("get", url, null);
+  }
+
+  async createTodo(name: string) {
+    const url = "/todos";
+    const body = {
+      todo: name,
+    };
+    return this.request<TodoListItemData>("get", url, body);
+  }
+
+  async updateTodo({ id, todo, isCompleted }: TodoListItemData) {
+    const url = `/todos/${id}`;
+    const body = {
+      todo,
+      isCompleted,
+    };
+    return this.request<TodoListItemData>("put", url, body);
+  }
+
+  async deleteTodo(id: number) {
+    const url = `/todos/${id}`;
+    await this.request("delete", url, null);
+  }
+}

--- a/src/pages/SignInpage.tsx
+++ b/src/pages/SignInpage.tsx
@@ -1,40 +1,13 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { BackendErrorResponse } from "../server";
-
-interface SignupFormData {
-  email: string;
-  password: string;
-}
-
-// TODO: 반환된 accessToken을 저장, 중복된 코드 컴포넌트화
-async function fetchSignIn(signupFormData: SignupFormData): Promise<string> {
-  const response = await fetch(
-    "https://pre-onboarding-selection-task.shop/auth/signin",
-    {
-      body: JSON.stringify(signupFormData),
-      method: "post",
-      headers: {
-        "Content-Type": "application/json",
-      },
-    }
-  );
-  console.log(response);
-  if (!response.ok) {
-    const body = (await response.json()) as BackendErrorResponse;
-    alert(body.message);
-    // TODO: 함수 진행 중단하기
-    return "";
-  }
-  // TODO: any인데 Typing하기
-  return (await response.json()).access_token;
-}
+import { AuthApi } from "../apis/AuthApi";
 
 interface SignInPageProps {
+  authApi: AuthApi;
   setAccessToken: (accessToken: string) => void;
 }
 
-export function SignInPage({ setAccessToken }: SignInPageProps) {
+export function SignInPage({ authApi, setAccessToken }: SignInPageProps) {
   const navigate = useNavigate();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -110,7 +83,7 @@ export function SignInPage({ setAccessToken }: SignInPageProps) {
           data-testid="signin-button"
           disabled={!submitAvailable}
           onClick={async () => {
-            const accessToken = await fetchSignIn({ email, password });
+            const accessToken = await authApi.signInApi({ email, password });
             setAccessToken(accessToken);
             navigate("/todo");
             localStorage.setItem("accessToken", accessToken);

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -1,40 +1,12 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { BackendErrorResponse } from "../server";
-
-interface SignupFormData {
-  email: string;
-  password: string;
-}
-
-// TODO: 반환된 accessToken을 저장, 중복된 코드 컴포넌트화
-async function fetchSignUp(signupFormData: SignupFormData) {
-  const response = await fetch(
-    "https://pre-onboarding-selection-task.shop/auth/signup",
-    {
-      body: JSON.stringify(signupFormData),
-      method: "post",
-      headers: {
-        "Content-Type": "application/json",
-      },
-    }
-  );
-  console.log(response);
-  if (!response.ok) {
-    const body = (await response.json()) as BackendErrorResponse;
-    alert(body.message);
-    return "";
-  }
-  const responseBody = await response.json();
-  console.log(responseBody);
-  return responseBody.access_token;
-}
+import { AuthApi } from "../apis/AuthApi";
 
 interface SignUpPageProps {
-  setAccessToken: (accessToken: string) => void;
+  authApi: AuthApi;
 }
 
-export function SignUpPage({ setAccessToken }: SignUpPageProps) {
+export function SignUpPage({ authApi }: SignUpPageProps) {
   const navigate = useNavigate();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -110,8 +82,7 @@ export function SignUpPage({ setAccessToken }: SignUpPageProps) {
           data-testid="signup-button"
           disabled={!submitAvailable}
           onClick={async () => {
-            const accessToken = await fetchSignUp({ email, password });
-            setAccessToken(accessToken);
+            await authApi.signUpApi({ email, password });
             navigate("/signin");
           }}
         >

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,12 @@
 import { useEffect, useState } from "react";
 import { BrowserRouter, Link, Outlet, Route, Routes } from "react-router-dom";
+import { AuthApi } from "../apis/AuthApi";
 import { SignInPage } from "./SignInpage";
 import { SignUpPage } from "./SignUpPage";
 import { TodoListPage } from "./TodoListPage";
+
+// 한 번 생성하면 끝이어서 컴포넌트 바깥에서 생성
+const authApi = new AuthApi("https://pre-onboarding-selection-task.shop");
 
 export const RootRouter = () => {
   const [loggedIn, setLoggedIn] = useState(false);
@@ -56,12 +60,14 @@ export const RootRouter = () => {
           />
           <Route
             path="signin"
-            element={<SignInPage setAccessToken={updateAccessToken} />}
+            element={
+              <SignInPage
+                authApi={authApi}
+                setAccessToken={updateAccessToken}
+              />
+            }
           />
-          <Route
-            path="signup"
-            element={<SignUpPage setAccessToken={updateAccessToken} />}
-          />
+          <Route path="signup" element={<SignUpPage authApi={authApi} />} />
           <Route
             path="todo"
             element={

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,19 +1,24 @@
 import { useEffect, useState } from "react";
 import { BrowserRouter, Link, Outlet, Route, Routes } from "react-router-dom";
 import { AuthApi } from "../apis/AuthApi";
+import { TodoApi } from "../apis/TodoApis";
 import { SignInPage } from "./SignInpage";
 import { SignUpPage } from "./SignUpPage";
 import { TodoListPage } from "./TodoListPage";
 
+const API_SERVER_URL = "https://pre-onboarding-selection-task.shop";
+
 // 한 번 생성하면 끝이어서 컴포넌트 바깥에서 생성
-const authApi = new AuthApi("https://pre-onboarding-selection-task.shop");
+const authApi = new AuthApi(API_SERVER_URL);
 
 export const RootRouter = () => {
+  const [todoApi, setTodoApi] = useState(new TodoApi(API_SERVER_URL));
   const [loggedIn, setLoggedIn] = useState(false);
   const [accessToken, setAccessToken] = useState("");
   const updateAccessToken = (newAccessToken: string) => {
     setAccessToken(newAccessToken);
     setLoggedIn(true);
+    setTodoApi(new TodoApi(API_SERVER_URL, accessToken));
   };
   const logout = () => {
     setAccessToken("");
@@ -26,6 +31,7 @@ export const RootRouter = () => {
     if (fromLocalStorage) {
       updateAccessToken(fromLocalStorage);
     }
+    // 함수는 바뀌지 않음
   }, []);
 
   return (
@@ -70,9 +76,7 @@ export const RootRouter = () => {
           <Route path="signup" element={<SignUpPage authApi={authApi} />} />
           <Route
             path="todo"
-            element={
-              <TodoListPage loggedIn={loggedIn} accessToken={accessToken} />
-            }
+            element={<TodoListPage loggedIn={loggedIn} todoApi={todoApi} />}
           />
           <Route
             path="*"


### PR DESCRIPTION
#fixes #15

## Tasks
- [x] fetch 로직 분리
- [x] fetch 로직의 캡슐화 및 코드 재사용 (`AuthApi.ts`, `TodoApi.ts`)