### PR TITLE
[#17, #18] Todo Create, Login 페이지 및 컴포넌트 리팩토링 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.46.0",
         "@typescript-eslint/parser": "^5.46.0",
+        "csstype": "^3.1.1",
         "eslint": "^8.29.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-config-react-app": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.46.0",
     "@typescript-eslint/parser": "^5.46.0",
+    "csstype": "^3.1.1",
     "eslint": "^8.29.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-config-react-app": "^7.0.1",

--- a/src/apis/AbstractApi.ts
+++ b/src/apis/AbstractApi.ts
@@ -22,7 +22,15 @@ export class AbstractApi {
     const response = await fetch(url, requestConfig);
 
     await this.assertResponseIsOk(response);
-    return response.json() as T;
+
+    // bugfix: response body가 없는 경우 오류 발생함
+    try {
+      const text = await response.text();
+      return JSON.parse(text) as T;
+    } catch (err) {
+      // TODO: T 제거
+      return null as T;
+    }
   }
 
   private createFetchConfig(requestMethod: string, inputData: object | null) {

--- a/src/apis/TodoApis.ts
+++ b/src/apis/TodoApis.ts
@@ -18,7 +18,7 @@ export class TodoApi extends AbstractApi {
     const body = {
       todo: name,
     };
-    return this.request<TodoListItemData>('get', url, body);
+    return this.request<TodoListItemData>('post', url, body);
   }
 
   async updateTodo({ id, todo, isCompleted }: TodoListItemData) {

--- a/src/components/AbstractUserField.tsx
+++ b/src/components/AbstractUserField.tsx
@@ -1,0 +1,49 @@
+import type * as CSS from 'csstype';
+
+interface UserAbstractFieldProps {
+  id: string;
+  name: string;
+  value: string;
+  type: 'text' | 'password';
+  handleChange: (newValue: string) => void;
+}
+
+const CotainerStyle: CSS.Properties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '4px',
+};
+
+const LabelStyle: CSS.Properties = {
+  display: 'block',
+};
+
+const InputStyle: CSS.Properties = {
+  height: '24px',
+  padding: '4px 8px',
+  fontSize: '16px',
+};
+
+export function UserAbstractField({
+  id,
+  name,
+  value,
+  type,
+  handleChange,
+}: UserAbstractFieldProps) {
+  return (
+    <div style={CotainerStyle}>
+      <label htmlFor={id} style={LabelStyle}>
+        {name}
+      </label>
+      <input
+        id={id}
+        data-testid={id}
+        type={type}
+        value={value}
+        onChange={(e) => handleChange(e.target.value)}
+        style={InputStyle}
+      />
+    </div>
+  );
+}

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,0 +1,67 @@
+import type * as CSS from 'csstype';
+import { useState } from 'react';
+import { UserEmailField } from './UserEmailField';
+import { UserPasswordField } from './UserPasswordField';
+
+const LoginFormStyle: CSS.Properties = {
+  display: 'flex',
+  flexDirection: 'column',
+  maxWidth: '300px',
+  gap: '16px',
+  padding: '32px 16px',
+  backgroundColor: 'darkgray',
+};
+
+const LoginButtonStyle: CSS.Properties = {
+  height: '48px',
+  marginTop: '4px',
+};
+
+interface LoginFormProps {
+  mode: 'signin' | 'signup';
+  handleSubmit: (email: string, password: string) => void;
+}
+
+export function LoginForm({ mode, handleSubmit }: LoginFormProps) {
+  const [email, setEmail] = useState('');
+  const [emailIsValid, setEmailIsvalid] = useState(false);
+  const [password, setPassword] = useState('');
+  const [passwordlIsValid, setPasswordlIsvalid] = useState(false);
+  const submitAvailable = emailIsValid && passwordlIsValid;
+
+  const updateEmail = (newEmail: string) => {
+    setEmailIsvalid(newEmail.includes('@'));
+    setEmail(newEmail);
+  };
+
+  const updatePassword = (newPassword: string) => {
+    setPasswordlIsvalid(newPassword.length >= 8);
+    setPassword(newPassword);
+  };
+
+  const handleButtonClick = () => handleSubmit(email, password);
+
+  return (
+    <div style={LoginFormStyle}>
+      <UserEmailField
+        id={`${mode}-email-input`}
+        value={email}
+        handleChange={updateEmail}
+      />
+      <UserPasswordField
+        id={`${mode}-password-input`}
+        value={password}
+        handleChange={updatePassword}
+      />
+      <button
+        style={LoginButtonStyle}
+        id={`${mode}-button`}
+        data-testid={`${mode}-button`}
+        disabled={!submitAvailable}
+        onClick={handleButtonClick}
+      >
+        로그인
+      </button>
+    </div>
+  );
+}

--- a/src/components/TodoCreateForm.tsx
+++ b/src/components/TodoCreateForm.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+
+export interface CreateFormProps {
+  onAddNewTodo: (name: string) => void;
+}
+
+export function TodoCreateForm({ onAddNewTodo: addNewTodo }: CreateFormProps) {
+  const [createInput, setCreateInput] = useState('');
+
+  return (
+    <>
+      <h2>Add new Todo!</h2>
+      <input
+        data-testid="new-todo-input"
+        value={createInput}
+        onChange={(e) => setCreateInput(e.target.value)}
+      />
+      <button
+        data-testid="new-todo-and-button"
+        onClick={async () => {
+          addNewTodo(createInput);
+          setCreateInput('');
+        }}
+      >
+        추가
+      </button>
+    </>
+  );
+}

--- a/src/components/UserEmailField.tsx
+++ b/src/components/UserEmailField.tsx
@@ -1,0 +1,23 @@
+import { UserAbstractField } from './AbstractUserField';
+
+interface UserEmailFieldProps {
+  id: string;
+  value: string;
+  handleChange: (newValue: string) => void;
+}
+
+export function UserEmailField({
+  id,
+  value,
+  handleChange,
+}: UserEmailFieldProps) {
+  return (
+    <UserAbstractField
+      id={id}
+      name="아이디"
+      value={value}
+      type="text"
+      handleChange={handleChange}
+    />
+  );
+}

--- a/src/components/UserPasswordField.tsx
+++ b/src/components/UserPasswordField.tsx
@@ -1,0 +1,23 @@
+import { UserAbstractField } from './AbstractUserField';
+
+interface UserPasswordFieldProps {
+  id: string;
+  value: string;
+  handleChange: (newValue: string) => void;
+}
+
+export function UserPasswordField({
+  id,
+  value,
+  handleChange,
+}: UserPasswordFieldProps) {
+  return (
+    <UserAbstractField
+      id={id}
+      name="비밀번호"
+      value={value}
+      type="password"
+      handleChange={handleChange}
+    />
+  );
+}

--- a/src/pages/SignInpage.tsx
+++ b/src/pages/SignInpage.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AuthApi } from '../apis/AuthApi';
+import { LoginForm } from '../components/LoginForm';
 
 interface SignInPageProps {
   authApi: AuthApi;
@@ -9,89 +9,18 @@ interface SignInPageProps {
 
 export function SignInPage({ authApi, setAccessToken }: SignInPageProps) {
   const navigate = useNavigate();
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [emailIsValid, setEmailIsvalid] = useState(false);
-  const [passwordlIsValid, setPasswordlIsvalid] = useState(false);
-  const submitAvailable = emailIsValid && passwordlIsValid;
 
-  const updateEmail = (newEmail: string) => {
-    // email 검사
-    setEmailIsvalid(newEmail.includes('@'));
-    setEmail(newEmail);
-  };
-
-  const updatePassword = (newPassword: string) => {
-    setPasswordlIsvalid(newPassword.length >= 8);
-    setPassword(newPassword);
+  const handleLogin = async (email: string, password: string) => {
+    const accessToken = await authApi.signInApi({ email, password });
+    setAccessToken(accessToken);
+    navigate('/todo');
+    localStorage.setItem('accessToken', accessToken);
   };
 
   return (
     <div>
       <h1>로그인 폼</h1>
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          maxWidth: 300,
-          gap: 16,
-          padding: '32px 16px',
-          backgroundColor: 'darkgray',
-        }}
-      >
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 4,
-          }}
-        >
-          <label htmlFor="signin-email-input" style={{ display: 'block' }}>
-            이메일
-          </label>
-          <input
-            id="signin-email-input"
-            data-testid="signin-email-input"
-            type="email"
-            value={email}
-            onChange={(e) => updateEmail(e.target.value)}
-            style={{ height: 24, padding: '4px 8px', fontSize: 16 }}
-          />
-        </div>
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 4,
-          }}
-        >
-          <label htmlFor="signin-password-input" style={{ display: 'block' }}>
-            비밀번호
-          </label>
-          <input
-            id="signin-password-input"
-            data-testid="signin-password-input"
-            type="password"
-            value={password}
-            onChange={(e) => updatePassword(e.target.value)}
-            style={{ height: 24, padding: '4px 8px', fontSize: 16 }}
-          />
-        </div>
-        <button
-          style={{ height: 48, marginTop: 4 }}
-          id="signin-button"
-          data-testid="signin-button"
-          disabled={!submitAvailable}
-          onClick={async () => {
-            const accessToken = await authApi.signInApi({ email, password });
-            setAccessToken(accessToken);
-            navigate('/todo');
-            localStorage.setItem('accessToken', accessToken);
-          }}
-        >
-          로그인
-        </button>
-      </div>
+      <LoginForm mode="signin" handleSubmit={handleLogin} />
     </div>
   );
 }

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AuthApi } from '../apis/AuthApi';
+import { LoginForm } from '../components/LoginForm';
 
 interface SignUpPageProps {
   authApi: AuthApi;
@@ -8,87 +8,16 @@ interface SignUpPageProps {
 
 export function SignUpPage({ authApi }: SignUpPageProps) {
   const navigate = useNavigate();
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [emailIsValid, setEmailIsvalid] = useState(false);
-  const [passwordlIsValid, setPasswordlIsvalid] = useState(false);
-  const submitAvailable = emailIsValid && passwordlIsValid;
 
-  const updateEmail = (newEmail: string) => {
-    // email 검사
-    setEmailIsvalid(newEmail.includes('@'));
-    setEmail(newEmail);
-  };
-
-  const updatePassword = (newPassword: string) => {
-    setPasswordlIsvalid(newPassword.length >= 8);
-    setPassword(newPassword);
+  const handleSignup = async (email: string, password: string) => {
+    await authApi.signUpApi({ email, password });
+    navigate('/signin');
   };
 
   return (
     <div>
       <h1>회원가입 폼</h1>
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          maxWidth: 300,
-          gap: 16,
-          padding: '32px 16px',
-          backgroundColor: 'darkgray',
-        }}
-      >
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 4,
-          }}
-        >
-          <label htmlFor="signup-email-input" style={{ display: 'block' }}>
-            이메일
-          </label>
-          <input
-            id="signup-email-input"
-            data-testid="signup-email-input"
-            type="email"
-            value={email}
-            onChange={(e) => updateEmail(e.target.value)}
-            style={{ height: 24, padding: '4px 8px', fontSize: 16 }}
-          />
-        </div>
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 4,
-          }}
-        >
-          <label htmlFor="signup-password-input" style={{ display: 'block' }}>
-            비밀번호
-          </label>
-          <input
-            id="signup-password-input"
-            data-testid="signup-password-input"
-            type="password"
-            value={password}
-            onChange={(e) => updatePassword(e.target.value)}
-            style={{ height: 24, padding: '4px 8px', fontSize: 16 }}
-          />
-        </div>
-        <button
-          style={{ height: 48, marginTop: 4 }}
-          id="signup-button"
-          data-testid="signup-button"
-          disabled={!submitAvailable}
-          onClick={async () => {
-            await authApi.signUpApi({ email, password });
-            navigate('/signin');
-          }}
-        >
-          회원가입
-        </button>
-      </div>
+      <LoginForm mode="signup" handleSubmit={handleSignup} />
     </div>
   );
 }

--- a/src/pages/TodoListPage.tsx
+++ b/src/pages/TodoListPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { TodoApi, TodoListItemData } from '../apis/TodoApis';
+import { TodoCreateForm } from '../components/TodoCreateForm';
 import { TodoListItem } from '../components/TodoListItem';
 
 interface TodoListPageProps {
@@ -13,7 +14,12 @@ interface TodoListPageProps {
 export function TodoListPage({ todoApi, loggedIn }: TodoListPageProps) {
   const [loaded, setLoaded] = useState(false);
   const [todos, setTodos] = useState<TodoListItemData[]>([]);
-  const [createInput, setCreateInput] = useState('');
+
+  const handleAddNewTodo = async (name: string) => {
+    const createdTodo = await todoApi.createTodo(name);
+    setTodos([...todos, createdTodo]);
+  };
+
   const handleCheckChange = (id: number) => async () => {
     // 이렇게 처리해도 될까? 모르겠네
     const toChange = todos.find((todo) => todo.id === id);
@@ -24,9 +30,7 @@ export function TodoListPage({ todoApi, loggedIn }: TodoListPageProps) {
     await todoApi.updateTodo(toChange);
     setTodos([...todos]);
   };
-  const addNewTodo = (newItem: TodoListItemData) => {
-    setTodos([...todos, newItem]);
-  };
+
   const handleSubmit = (id: number) => async (name: string) => {
     // 이렇게 처리해도 될까? 모르겠네
     const toChange = todos.find((todo) => todo.id === id);
@@ -37,6 +41,7 @@ export function TodoListPage({ todoApi, loggedIn }: TodoListPageProps) {
     await todoApi.updateTodo(toChange);
     setTodos([...todos]);
   };
+
   const handleDelete = (id: number) => async () => {
     await todoApi.deleteTodo(id);
     setTodos(todos.filter((todo) => todo.id !== id));
@@ -48,7 +53,6 @@ export function TodoListPage({ todoApi, loggedIn }: TodoListPageProps) {
       if (!loggedIn) {
         return;
       }
-
       const todos = await todoApi.fetchTodos();
       setTodos(todos);
       setLoaded(true);
@@ -70,6 +74,7 @@ export function TodoListPage({ todoApi, loggedIn }: TodoListPageProps) {
       </div>
     );
   }
+
   return (
     <div>
       <h1>Your todos:</h1>
@@ -79,36 +84,20 @@ export function TodoListPage({ todoApi, loggedIn }: TodoListPageProps) {
         </div>
       ) : (
         <ol style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-          {todos.map((todo) => (
-            <li key={todo.id}>
+          {todos.map(({ id, todo, isCompleted }) => (
+            <li key={id}>
               <TodoListItem
-                name={todo.todo}
-                checked={todo.isCompleted}
-                handleCheck={handleCheckChange(todo.id)}
-                handleSubmit={handleSubmit(todo.id)}
-                handleDelete={handleDelete(todo.id)}
+                name={todo}
+                checked={isCompleted}
+                handleCheck={handleCheckChange(id)}
+                handleSubmit={handleSubmit(id)}
+                handleDelete={handleDelete(id)}
               />
             </li>
           ))}
         </ol>
       )}
-      {/* 이걸 따로 빼면 뭐가 힘들까? */}
-      <h2>Add new Todo!</h2>
-      <input
-        data-testid="new-todo-input"
-        value={createInput}
-        onChange={(e) => setCreateInput(e.target.value)}
-      />
-      <button
-        data-testid="new-todo-and-button"
-        onClick={async () => {
-          const createdTodo = await todoApi.createTodo(createInput);
-          addNewTodo(createdTodo);
-          setCreateInput('');
-        }}
-      >
-        추가
-      </button>
+      <TodoCreateForm onAddNewTodo={handleAddNewTodo} />
     </div>
   );
 }


### PR DESCRIPTION
fixes #17
fixes #18 

## Results

Todo 생성
- [x] 신규 컴포넌트: `TodoCreateForm`
- [x] 리팩토링된 페이지: `TodoListPage` (11라인 감소)

Login 페이지
- [x] 신규 컴포넌트: `AbstractUserField`, `UserEmailField`, `UserPasswordField`, `LoginForm`
- [x] 리팩토링된 페이지: `SignInpage`, `SignUpPage` (각각 71라인 감소)
